### PR TITLE
List all urls in one 'baseurl'

### DIFF
--- a/fedberry-testing.repo
+++ b/fedberry-testing.repo
@@ -1,7 +1,7 @@
 [fedberry-testing]
 name=FedBerry Testing $releasever
 baseurl=http://download.fedberry.org/releases/$releasever/packages/armhfp/testing/
-baseurl=https://vaughan.fedorapeople.org/releases/$releasever/packages/armhfp/testing/
+        https://vaughan.fedorapeople.org/releases/$releasever/packages/armhfp/testing/
 enabled=0
 gpgcheck=1
 metadata_expire=6h

--- a/fedberry-unstable.repo
+++ b/fedberry-unstable.repo
@@ -1,7 +1,7 @@
 [fedberry-unstable]
 name=FedBerry Unstable $releasever
 baseurl=http://download.fedberry.org/releases/$releasever/packages/armhfp/unstable/
-baseurl=https://vaughan.fedorapeople.org/releases/$releasever/packages/armhfp/unstable/
+        https://vaughan.fedorapeople.org/releases/$releasever/packages/armhfp/unstable/
 enabled=0
 gpgcheck=1
 metadata_expire=6h

--- a/fedberry.repo
+++ b/fedberry.repo
@@ -1,7 +1,7 @@
 [fedberry]
 name=FedBerry $releasever
 baseurl=http://download.fedberry.org/releases/$releasever/packages/armhfp/stable/
-baseurl=https://vaughan.fedorapeople.org/releases/$releasever/packages/armhfp/stable/
+        https://vaughan.fedorapeople.org/releases/$releasever/packages/armhfp/stable/
 enabled=1
 gpgcheck=1
 metadata_expire=6h


### PR DESCRIPTION
Having multiple `baseurl` statements is discouraged by `yum.conf(5)`:

```
If you list more than one baseurl= statement in a repository
you will find yum will ignore the earlier ones and probably
act bizarrely. Don't do this, you've been warned.
```

And in this case you can not parse .repo files as ini.
